### PR TITLE
Illustration for global interface for options

### DIFF
--- a/service_client.go
+++ b/service_client.go
@@ -121,6 +121,14 @@ func (client *ServiceClient) Head(url string, opts *RequestOpts) (*http.Response
 	return client.Request("HEAD", url, opts)
 }
 
+func (client *ServiceClient) Get2(url string, opts RequestOptions) (*http.Response, error) {
+	return client.ProviderClient.Request2("GET", url, opts)
+}
+
+func (client *ServiceClient) Post2(url string, opts RequestOptions) (*http.Response, error) {
+	return client.ProviderClient.Request2("POST", url, opts)
+}
+
 func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 	switch client.Type {
 	case "compute":


### PR DESCRIPTION
This PR exists only as an illustration to discussion in https://github.com/gophercloud/gophercloud/issues/441

Point here is to demonstrate how `RequestOptions` could be passed all a way down to `ProviderClient` without being rendered into `map[string]interfaces{}` in a middle. This eliminates necessity of having one interface per Opts structure which kind of defeats the purpose of interfaces.

Use case could be 
```
import (
    "github.com/gophercloud/openstack/blockstorage/extensions/volumeactions"
    "github.com/gophercloud"
)

var client gophercloud.ServiceClient

func SomeClientFunc () {
  opts := volumeactions.AttachOptions{
    microversion = "3.33",
    MountPoint = "/mnt",
    InstanceUUID = "...",
  }
  must(&opts.Validate())
  res, err := client.Post2(url, opts)
}